### PR TITLE
Add up loading of test reports on failure

### DIFF
--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -52,7 +52,18 @@ jobs:
           uses: gradle/gradle-build-action@v2
           with:
             arguments: ${{ inputs.gradle_tasks }}
-        
+            
+        - name: Store reports
+          if: failure()
+          uses: actions/upload-artifact@v4
+          with:
+            name: reports
+            # Not all builds have tests
+            if-no-files-found: ignore
+            path: |
+              **/build/reports/
+              **/build/test-results/
+
         - name: Run JCC
           uses: gradle/gradle-build-action@v2
           if: inputs.jar_compatibility


### PR DESCRIPTION
We're using junit tests in several repositories and currently it is very hard to analyze failures.
This change is supposed to upload the test reports as a build artifact when it fails so that they can be analyzed.