### PR TITLE
Updates Kits Workflow

### DIFF
--- a/.github/workflows/start-kits.yml
+++ b/.github/workflows/start-kits.yml
@@ -24,11 +24,10 @@ jobs:
         with:
           groovy-version: '4.0.18'
 
-      - name: Setup JDK 21
-        uses: actions/setup-java@v2
-        with:
-          java-version: '21'
-          distribution: 'temurin'
+      # The Ubuntu runners come with Java 21 pre-installed
+      # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
+      - name: Setup Java 21
+        run: echo "JAVA_HOME=$(echo $JAVA_HOME_21_X64)" >> "$GITHUB_ENV"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/start-kits.yml
+++ b/.github/workflows/start-kits.yml
@@ -24,6 +24,15 @@ jobs:
         with:
           groovy-version: '4.0.18'
 
+      - name: Setup JDK 21
+        uses: actions/setup-java@v2
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Generate an Application repository access token
         id: gen_repo_token
         uses: kattecon/gh-app-access-token-gen@v1
@@ -52,10 +61,8 @@ jobs:
           git fetch --tags upstream
           git switch -c ${{ inputs.mc_version }} upstream/${{ inputs.upstream_branch }}
 
-      - name: Build initially with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-            arguments: setup
+      - name: Setup sources with old MC version
+        run: ./gradlew setup
 
       - name: Commit initial
         run: |
@@ -74,15 +81,9 @@ jobs:
           git add gradle.properties
           git commit -m "Update versions"
 
-      - name: Make Gradlew executable
-        # language=bash
-        run: chmod +x ./gradlew # Thanks Windows
+      - name: Setup with new MC version
+        run: ./gradlew setup -Pupdating=true
 
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: setup -Pupdating=true
-      
       - name: Commit MC Sources
         run: |
           git add --force projects/base/src

--- a/.github/workflows/start-kits.yml
+++ b/.github/workflows/start-kits.yml
@@ -30,7 +30,7 @@ jobs:
         run: echo "JAVA_HOME=$(echo $JAVA_HOME_21_X64)" >> "$GITHUB_ENV"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Generate an Application repository access token
         id: gen_repo_token


### PR DESCRIPTION
This updates the Kits Workflow as follows:

- Explicitly setup Java for Gradle. Previously the Runners default java was used (This effectively upgrades Java 11 to Java 21)
- Use the new Gradle Setup actions and run Gradle Tasks directly with `./gradlew`
- Remove the permission change on `gradlew` since the wrapper shell-script now has correct permissions in the NeoForge repository