### PR TITLE
Add support for graphics_environment to gradle-publish.yml

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -34,6 +34,11 @@ on:
         required: false
         type: boolean
         default: true
+      graphics_environment:
+          description: "If enabled, provides graphical capabilities using software OpenGL rendering and Xvfb"
+          required: false
+          type: boolean
+          default: false
     secrets:
       DISCORD_WEBHOOK:
         required: true
@@ -161,11 +166,11 @@ jobs:
       - name: Gradle pre-publication tasks
         if: inputs.pre_gradle_tasks
         run: |
-          ./gradlew ${{ inputs.pre_gradle_tasks }}
+          ${{ inputs.graphics_environment && 'xvfb-run' || '' }} ./gradlew ${{ inputs.pre_gradle_tasks }}
 
       - name: Gradle ${{ inputs.gradle_tasks }}
         run: |
-          ./gradlew ${{ inputs.gradle_tasks }}
+          ${{ inputs.graphics_environment && 'xvfb-run' || '' }} ./gradlew ${{ inputs.gradle_tasks }}
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}


### PR DESCRIPTION
Needed for parity with build-prs.yml to enable tests in publish workflows that also use graphics in their normal PR builds.